### PR TITLE
Skip zero-initializing memory.

### DIFF
--- a/DirectX/player/commandPlayer.h
+++ b/DirectX/player/commandPlayer.h
@@ -50,8 +50,8 @@ public:
   void Read(CBinIStream& stream) override {
     unsigned size = 0;
     stream.read(reinterpret_cast<char*>(&size), sizeof(unsigned));
-    data_.resize(size);
-    stream.read(data_.data(), size);
+    data_ = HeapArray<char>(size);
+    stream.read(reinterpret_cast<char*>(data_.data()), size);
 
     decodeCommand();
   }
@@ -64,7 +64,7 @@ protected:
   virtual void decodeCommand() {}
 
 protected:
-  std::vector<char> data_;
+  HeapArray<char> data_;
 
 private:
   FakeArgument argument_;

--- a/DirectX/player/commandPlayer.h
+++ b/DirectX/player/commandPlayer.h
@@ -51,7 +51,7 @@ public:
     unsigned size = 0;
     stream.read(reinterpret_cast<char*>(&size), sizeof(unsigned));
     data_ = HeapArray<char>(size);
-    stream.read(reinterpret_cast<char*>(data_.data()), size);
+    stream.read(data_.data(), size);
 
     decodeCommand();
   }

--- a/common/legacy/include/tools.h
+++ b/common/legacy/include/tools.h
@@ -641,4 +641,56 @@ public:
   }
 };
 
+template <typename T = std::byte>
+class HeapArray
+{
+public:
+  HeapArray() {}
+  HeapArray(const std::size_t size) : size_(size) {
+    data_ = new T[size];
+  }
+
+  ~HeapArray() {
+    delete[] data_;
+  }
+
+  std::size_t size() const {
+    return size_;
+  }
+
+  const T* data() const {
+    return data_;
+  }
+
+  T* data() {
+    return data_;
+  }
+
+  HeapArray& operator=(const HeapArray& other) = delete;
+  HeapArray(const HeapArray& other) = delete;
+
+  HeapArray& operator=(HeapArray&& other) {
+    delete[] data_;
+    data_ = other.data_;
+    size_ = other.size_;
+
+    other.data_ = nullptr;
+    other.size_ = 0;
+
+    return *this;
+  }
+
+  HeapArray(HeapArray&& other) {
+    data_ = other.data_;
+    size_ = other.size_;
+
+    other.data_ = nullptr;
+    other.size_ = 0;
+  }
+
+private:
+  T* data_ = nullptr;
+  std::size_t size_ = 0;
+};
+
 } // namespace gits

--- a/common/legacy/include/tools.h
+++ b/common/legacy/include/tools.h
@@ -642,8 +642,7 @@ public:
 };
 
 template <typename T = std::byte>
-class HeapArray
-{
+class HeapArray {
 public:
   HeapArray() {}
   HeapArray(const std::size_t size) : size_(size) {
@@ -669,7 +668,7 @@ public:
   HeapArray& operator=(const HeapArray& other) = delete;
   HeapArray(const HeapArray& other) = delete;
 
-  HeapArray& operator=(HeapArray&& other) {
+  HeapArray& operator=(HeapArray&& other) noexcept {
     delete[] data_;
     data_ = other.data_;
     size_ = other.size_;


### PR DESCRIPTION
The memory in question here is immediately overwritten, so no need to initialize to zero. Saves ~3.5% load time. I've put it into a class (`HeapArray`) for simpler RAII; here we could also allocate inline (I think) using `new`/`delete` because nobody is making copies anyways.

Before:

```
Stalled loading: 4102.03ms
Played back in: 4340.01ms
```

After:

```
Stalled loading: 3969.49ms
Played back in: 4206.71ms
```